### PR TITLE
Fix pcs location constraint - allow options

### DIFF
--- a/library/pcs_constraint
+++ b/library/pcs_constraint
@@ -39,7 +39,7 @@ def main():
         argument_spec  = dict(
             command    = dict(choices=['order', 'location', 'colocation', 'rule']),
             name       = dict(required=True, aliases=['id', 'constraint_id']),
-            options    = dict(required=False),
+            options    = dict(required=False, type='dict'),
             force      = dict(default='no', required=False, choices=['yes', 'no']),
             operations = dict(required=False),
             score      = dict(default='INFINITY'),
@@ -117,7 +117,7 @@ def main():
             except ValueError:
                 module.fail_json(msg="Invocation failed. Parameter 'score' should be integer or +_INFINITY")
         changed = True
-        cmd = 'pcs constraint location add %(name)s %(resource)s %(node)s %(score)s'
+        cmd = 'pcs constraint location add %(name)s %(resource)s %(node)s %(score)s %(options)s'
 
     elif module.params['command'] == 'order':
         rc, out, err = module.run_command('pcs constraint %(command)s show --full' % module.params)


### PR DESCRIPTION
I encountered an error when running this task

```yaml
- pcs_constraint:
    command: location
    name: z
    resource: "x"
    node: y
    score: "-INFINITY"
    options:
      resource-discovery: never
```


```
Traceback (most recent call last):
  File "/tmp/ansible_Zg0AX0/ansible_module_pcs_constraint.py", line 163, in <module>
    main()
  File "/tmp/ansible_Zg0AX0/ansible_module_pcs_constraint.py", line 109, in main
    options = module.params['options'].items()
AttributeError: 'str' object has no attribute 'items'

```